### PR TITLE
Pull Request with a small bug fix to the table header sizing.

### DIFF
--- a/table-fixed-header.js
+++ b/table-fixed-header.js
@@ -17,8 +17,10 @@ $.fn.fixedHeader = function (options) {
 
   function processScroll() {
     if (!o.is(':visible')) return;
-    if ($('thead.header-copy').size())
-    var i, scrollTop = $win.scrollTop();
+	if ($('thead.header-copy').size()) {
+		$('thead.header-copy').width($('thead.header').width());
+		var i, scrollTop = $win.scrollTop();
+	}
     var t = $head.length && $head.offset().top - config.topOffset;
     if (!isFixed && headTop != t) { headTop = t; }
     if (scrollTop >= headTop && !isFixed) {


### PR DESCRIPTION
Fixed an issue whereby fixed header was incorrectly sized when the browser window was
resized after loading the page containing the fixed header.

This involves re-setting the width of the copied thead-header to that of the original thead-header.
