### PR TITLE
Cloning the bound events

### DIFF
--- a/table-fixed-header.js
+++ b/table-fixed-header.js
@@ -38,7 +38,7 @@ $.fn.fixedHeader = function (options) {
     if (!isFixed) setTimeout(function () {  $win.scrollTop($win.scrollTop() - 47) }, 10);
   })
 
-  $head.clone().removeClass('header').addClass('header-copy header-fixed').css({'position': 'fixed', 'top': config['topOffset']}).appendTo(o);
+  $head.clone(true).removeClass('header').addClass('header-copy header-fixed').css({'position': 'fixed', 'top': config['topOffset']}).appendTo(o);
   o.find('thead.header-copy').width($head.width());
 
   o.find('thead.header > tr > th').each(function (i, h) {


### PR DESCRIPTION
Passing the "true" parameter to the .clone() method allows the fixed header to keep bounded events.
